### PR TITLE
App filter (white/blacklist), aggressive OTP search option

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,8 +9,12 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
-    <!-- Package visibility for Gmail detection (Android 11+) -->
+    <!-- Package visibility for app filter list and Gmail detection (Android 11+) -->
     <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
         <package android:name="com.google.android.gm" />
         <package android:name="com.google.android.gm.lite" />
     </queries>
@@ -42,6 +46,13 @@
             android:name=".GmailOptimizationActivity"
             android:exported="false"
             android:label="Gmail Optimization"
+            android:parentActivityName=".MainActivity" />
+
+        <!-- App Filter Activity -->
+        <activity
+            android:name=".AppFilterActivity"
+            android:exported="false"
+            android:label="App Filters"
             android:parentActivityName=".MainActivity" />
 
         <!-- New OTP Listener Service -->

--- a/app/src/main/java/com/otpextractor/gmail/AppFilterActivity.kt
+++ b/app/src/main/java/com/otpextractor/gmail/AppFilterActivity.kt
@@ -1,0 +1,112 @@
+package com.otpextractor.secureotp
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.snackbar.Snackbar
+import com.otpextractor.secureotp.databinding.ActivityAppFilterBinding
+import com.otpextractor.secureotp.utils.AppFilterRepository
+import com.otpextractor.secureotp.utils.AppFilterState
+import kotlinx.coroutines.*
+
+class AppFilterActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityAppFilterBinding
+    private lateinit var filterRepo: AppFilterRepository
+    private val activityScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityAppFilterBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        filterRepo = AppFilterRepository(this)
+
+        binding.toolbar.setNavigationOnClickListener { finish() }
+
+        binding.tvEmpty.visibility = View.VISIBLE
+        binding.tvEmpty.text = getString(R.string.app_filter_loading)
+        binding.recyclerApps.layoutManager = LinearLayoutManager(this)
+
+        activityScope.launch {
+            val apps = withContext(Dispatchers.IO) { loadInstalledApps() }
+            binding.tvEmpty.visibility = View.GONE
+            binding.bulkActions.visibility = View.VISIBLE
+            val adapter = AppFilterAdapter(apps, filterRepo)
+            binding.recyclerApps.adapter = adapter
+
+            val allPackages = apps.map { it.packageName }
+
+            binding.btnAllAuto.setOnClickListener { applyBulk(allPackages, AppFilterState.DEFAULT, "All set to Auto", adapter) }
+            binding.btnAllOff.setOnClickListener { applyBulk(allPackages, AppFilterState.BLACKLISTED, "All set to Off", adapter) }
+            binding.btnAllMax.setOnClickListener { applyBulk(allPackages, AppFilterState.WHITELISTED, "All set to Max", adapter) }
+
+            binding.etSearch.addTextChangedListener(object : TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+                override fun afterTextChanged(s: Editable?) {
+                    adapter.filter(s?.toString() ?: "")
+                }
+            })
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        activityScope.cancel()
+    }
+
+    private fun applyBulk(packages: List<String>, state: AppFilterState, message: String, adapter: AppFilterAdapter) {
+        val previous = filterRepo.snapshot(packages)
+        filterRepo.setAll(packages, state)
+        adapter.notifyDataSetChanged()
+
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG)
+            .setAction("Undo") {
+                filterRepo.restore(previous)
+                adapter.notifyDataSetChanged()
+            }
+            .show()
+    }
+
+    private fun loadInstalledApps(): List<AppInfo> {
+        val pm = packageManager
+        val ownPackage = packageName
+
+        // Query apps that have a launcher icon — this gives us every app
+        // the user sees in their app drawer, including pre-installed ones
+        // like Gmail, WhatsApp, banking apps, etc.
+        val launcherIntent = Intent(Intent.ACTION_MAIN).apply {
+            addCategory(Intent.CATEGORY_LAUNCHER)
+        }
+
+        return pm.queryIntentActivities(launcherIntent, PackageManager.MATCH_ALL)
+            .map { it.activityInfo.applicationInfo }
+            .distinctBy { it.packageName }
+            .filter { it.packageName != ownPackage }
+            .map { appInfo ->
+                AppInfo(
+                    name = pm.getApplicationLabel(appInfo).toString(),
+                    packageName = appInfo.packageName,
+                    icon = try { pm.getApplicationIcon(appInfo) } catch (_: Exception) { null }
+                )
+            }
+            .sortedWith(
+                compareByDescending<AppInfo> {
+                    filterRepo.getState(it.packageName) != AppFilterState.DEFAULT
+                }.thenBy { it.name.lowercase() }
+            )
+    }
+}
+
+data class AppInfo(
+    val name: String,
+    val packageName: String,
+    val icon: Drawable?
+)

--- a/app/src/main/java/com/otpextractor/gmail/AppFilterAdapter.kt
+++ b/app/src/main/java/com/otpextractor/gmail/AppFilterAdapter.kt
@@ -1,0 +1,88 @@
+package com.otpextractor.secureotp
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import com.otpextractor.secureotp.databinding.ItemAppFilterBinding
+import com.otpextractor.secureotp.utils.AppFilterRepository
+import com.otpextractor.secureotp.utils.AppFilterState
+
+class AppFilterAdapter(
+    private val allApps: List<AppInfo>,
+    private val filterRepo: AppFilterRepository
+) : RecyclerView.Adapter<AppFilterAdapter.ViewHolder>() {
+
+    private var filteredApps: List<AppInfo> = allApps
+
+    init {
+        setHasStableIds(true)
+    }
+
+    fun filter(query: String) {
+        filteredApps = if (query.isBlank()) {
+            allApps
+        } else {
+            val lower = query.lowercase()
+            allApps.filter {
+                it.name.lowercase().contains(lower) ||
+                    it.packageName.lowercase().contains(lower)
+            }
+        }
+        notifyDataSetChanged()
+    }
+
+    class ViewHolder(val binding: ItemAppFilterBinding) : RecyclerView.ViewHolder(binding.root)
+
+    override fun getItemId(position: Int) = filteredApps[position].packageName.hashCode().toLong()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemAppFilterBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val app = filteredApps[position]
+        val b = holder.binding
+
+        b.imgAppIcon.setImageDrawable(app.icon)
+        b.tvAppName.text = app.name
+        b.tvPackageName.text = app.packageName
+
+        val buttons = listOf(
+            b.btnOff to AppFilterState.BLACKLISTED,
+            b.btnAuto to AppFilterState.DEFAULT,
+            b.btnMax to AppFilterState.WHITELISTED
+        )
+
+        val state = filterRepo.getState(app.packageName)
+        for ((btn, s) in buttons) {
+            styleButton(btn, s == state)
+        }
+
+        for ((btn, s) in buttons) {
+            btn.setOnClickListener {
+                filterRepo.setState(app.packageName, s)
+                for ((b2, s2) in buttons) {
+                    styleButton(b2, s2 == s)
+                }
+            }
+        }
+    }
+
+    private fun styleButton(tv: TextView, selected: Boolean) {
+        if (selected) {
+            tv.setBackgroundResource(R.drawable.bg_segment_selected)
+            tv.setTextColor(Color.WHITE)
+        } else {
+            tv.setBackgroundResource(R.drawable.bg_segment_unselected)
+            tv.setTextColor(ContextCompat.getColor(tv.context, R.color.text_primary))
+        }
+    }
+
+    override fun getItemCount() = filteredApps.size
+}

--- a/app/src/main/java/com/otpextractor/gmail/MainActivity.kt
+++ b/app/src/main/java/com/otpextractor/gmail/MainActivity.kt
@@ -110,6 +110,10 @@ class MainActivity : AppCompatActivity() {
             openGmailOptimization()
         }
 
+        binding.btnAppFilters.setOnClickListener {
+            startActivity(Intent(this, AppFilterActivity::class.java))
+        }
+
         setupWarningBanner()
     }
 

--- a/app/src/main/java/com/otpextractor/gmail/service/OtpListener.kt
+++ b/app/src/main/java/com/otpextractor/gmail/service/OtpListener.kt
@@ -17,6 +17,8 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.otpextractor.secureotp.OtpExtractorApp
 import com.otpextractor.secureotp.R
+import com.otpextractor.secureotp.utils.AppFilterRepository
+import com.otpextractor.secureotp.utils.AppFilterState
 import com.otpextractor.secureotp.utils.OtpExtractor
 import com.otpextractor.secureotp.utils.PreferenceManager
 import kotlinx.coroutines.*
@@ -24,6 +26,7 @@ import kotlinx.coroutines.*
 class OtpListener : NotificationListenerService() {
 
     private lateinit var prefManager: PreferenceManager
+    private lateinit var filterRepo: AppFilterRepository
     private val processedNotifications = mutableSetOf<String>()
     private val serviceScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private var wakeLock: PowerManager.WakeLock? = null
@@ -31,7 +34,8 @@ class OtpListener : NotificationListenerService() {
     override fun onCreate() {
         super.onCreate()
         prefManager = PreferenceManager(this)
-        
+        filterRepo = AppFilterRepository(this)
+
         // Initialize WakeLock for efficient battery usage
         val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
         wakeLock = powerManager.newWakeLock(
@@ -83,8 +87,18 @@ class OtpListener : NotificationListenerService() {
 
                     Log.d(TAG, "Notification content from ${sbn.packageName}: $fullText")
 
-                    // Extract OTP with context
-                    val otp = OtpExtractor.extractOtp(fullText)
+                    // Check app filter state
+                    val filterState = filterRepo.getState(sbn.packageName)
+                    if (filterState == AppFilterState.BLACKLISTED) {
+                        Log.d(TAG, "Skipping blacklisted app: ${sbn.packageName}")
+                        return@launch
+                    }
+
+                    // Extract OTP — aggressive mode for whitelisted apps
+                    val otp = when (filterState) {
+                        AppFilterState.WHITELISTED -> OtpExtractor.extractOtpAggressive(fullText)
+                        else -> OtpExtractor.extractOtp(fullText)
+                    }
                     if (otp != null) {
                         Log.d(TAG, "OTP found: $otp from ${sbn.packageName}")
                         processedNotifications.add(notificationKey)

--- a/app/src/main/java/com/otpextractor/gmail/utils/AppFilterRepository.kt
+++ b/app/src/main/java/com/otpextractor/gmail/utils/AppFilterRepository.kt
@@ -1,0 +1,55 @@
+package com.otpextractor.secureotp.utils
+
+import android.content.Context
+
+enum class AppFilterState {
+    DEFAULT, BLACKLISTED, WHITELISTED
+}
+
+class AppFilterRepository(context: Context) {
+    private val prefs = context.getSharedPreferences(
+        "app_filters", Context.MODE_PRIVATE
+    )
+
+    fun getState(packageName: String): AppFilterState {
+        val value = prefs.getString(packageName, null)
+        return value?.let { AppFilterState.valueOf(it) }
+            ?: AppFilterState.DEFAULT
+    }
+
+    fun setState(packageName: String, state: AppFilterState) {
+        if (state == AppFilterState.DEFAULT) {
+            prefs.edit().remove(packageName).apply()
+        } else {
+            prefs.edit().putString(packageName, state.name).apply()
+        }
+    }
+
+    fun snapshot(packageNames: List<String>): Map<String, AppFilterState> {
+        return packageNames.associateWith { getState(it) }
+    }
+
+    fun restore(snapshot: Map<String, AppFilterState>) {
+        val editor = prefs.edit()
+        for ((pkg, state) in snapshot) {
+            if (state == AppFilterState.DEFAULT) {
+                editor.remove(pkg)
+            } else {
+                editor.putString(pkg, state.name)
+            }
+        }
+        editor.apply()
+    }
+
+    fun setAll(packageNames: List<String>, state: AppFilterState) {
+        val editor = prefs.edit()
+        for (pkg in packageNames) {
+            if (state == AppFilterState.DEFAULT) {
+                editor.remove(pkg)
+            } else {
+                editor.putString(pkg, state.name)
+            }
+        }
+        editor.apply()
+    }
+}

--- a/app/src/main/java/com/otpextractor/gmail/utils/OtpExtractor.kt
+++ b/app/src/main/java/com/otpextractor/gmail/utils/OtpExtractor.kt
@@ -257,6 +257,26 @@ object OtpExtractor {
     }
 
     /**
+     * Aggressive OTP extraction for whitelisted apps.
+     * Tries standard extraction first, then falls back to broader patterns
+     * (short numeric codes, uppercase letter codes like Cl@ve).
+     */
+    fun extractOtpAggressive(text: String): String? {
+        // Try standard patterns first
+        extractOtp(text)?.let { return it }
+
+        // Short numeric codes (3+ digits)
+        Regex("\\b(\\d{3,8})\\b").find(text)
+            ?.let { return it.groupValues[1] }
+
+        // Uppercase letter codes (Cl@ve style)
+        Regex("\\b([A-Z]{3,6})\\b").find(text)
+            ?.let { return it.groupValues[1] }
+
+        return null
+    }
+
+    /**
      * Extracts all potential OTPs from text (for debugging/testing)
      */
     fun extractAllPotentialOtps(text: String): List<String> {

--- a/app/src/main/res/drawable/bg_segment_selected.xml
+++ b/app/src/main/res/drawable/bg_segment_selected.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/primary" />
+    <corners android:radius="6dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_segment_unselected.xml
+++ b/app/src/main/res/drawable/bg_segment_unselected.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#00000000" />
+    <stroke android:width="1dp" android:color="@color/text_hint" />
+    <corners android:radius="6dp" />
+</shape>

--- a/app/src/main/res/drawable/ic_filter_list.xml
+++ b/app/src/main/res/drawable/ic_filter_list.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,18h4v-2h-4v2zM3,6v2h18V6H3zm3,7h12v-2H6v2z" />
+</vector>

--- a/app/src/main/res/layout/activity_app_filter.xml
+++ b/app/src/main/res/layout/activity_app_filter.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.Material3.Dark">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="App Filters"
+            app:navigationIcon="@drawable/ic_arrow_back" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <!-- Explanation card -->
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            app:cardElevation="2dp"
+            app:cardCornerRadius="12dp"
+            app:cardBackgroundColor="#E3F2FD">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/app_filter_info_title"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/primary" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/app_filter_info_desc"
+                    android:textSize="12sp"
+                    android:textColor="@color/text_secondary"
+                    android:layout_marginTop="4dp"
+                    android:lineSpacingExtra="2dp" />
+
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- Search bar -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            app:startIconDrawable="@android:drawable/ic_menu_search"
+            app:boxCornerRadiusTopStart="12dp"
+            app:boxCornerRadiusTopEnd="12dp"
+            app:boxCornerRadiusBottomStart="12dp"
+            app:boxCornerRadiusBottomEnd="12dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etSearch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/app_filter_search_hint"
+                android:inputType="text"
+                android:imeOptions="actionDone"
+                android:maxLines="1" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Bulk action buttons -->
+        <LinearLayout
+            android:id="@+id/bulkActions"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:paddingHorizontal="16dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="4dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnAllAuto"
+                android:layout_width="0dp"
+                android:layout_height="36dp"
+                android:layout_weight="1"
+                android:layout_marginEnd="4dp"
+                android:text="All Auto"
+                android:textSize="12sp"
+                style="@style/Widget.Material3.Button.OutlinedButton" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnAllOff"
+                android:layout_width="0dp"
+                android:layout_height="36dp"
+                android:layout_weight="1"
+                android:layout_marginHorizontal="4dp"
+                android:text="All Off"
+                android:textSize="12sp"
+                style="@style/Widget.Material3.Button.OutlinedButton" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnAllMax"
+                android:layout_width="0dp"
+                android:layout_height="36dp"
+                android:layout_weight="1"
+                android:layout_marginStart="4dp"
+                android:text="All Max"
+                android:textSize="12sp"
+                style="@style/Widget.Material3.Button.OutlinedButton" />
+
+        </LinearLayout>
+
+        <!-- Empty state -->
+        <TextView
+            android:id="@+id/tvEmpty"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/app_filter_loading"
+            android:textAlignment="center"
+            android:textColor="@color/text_secondary"
+            android:padding="32dp"
+            android:visibility="gone" />
+
+        <!-- App list -->
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerApps"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:clipToPadding="false"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="16dp"
+            tools:listitem="@layout/item_app_filter" />
+
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -152,6 +152,20 @@
 
     </com.google.android.material.card.MaterialCardView>
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnAppFilters"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="App Filters"
+        android:textAllCaps="false"
+        android:layout_marginTop="16dp"
+        style="@style/Widget.Material3.Button.TonalButton"
+        app:icon="@drawable/ic_filter_list"
+        app:iconGravity="start"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cardService" />
+
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/cardInfo"
         android:layout_width="0dp"
@@ -162,7 +176,7 @@
         app:cardBackgroundColor="#E3F2FD"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/cardService">
+        app:layout_constraintTop_toBottomOf="@id/btnAppFilters">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_app_filter.xml
+++ b/app/src/main/res/layout/item_app_filter.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingHorizontal="4dp"
+    android:paddingVertical="10dp"
+    android:gravity="center_vertical">
+
+    <ImageView
+        android:id="@+id/imgAppIcon"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:contentDescription="App icon"
+        tools:src="@mipmap/ic_launcher" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="8dp">
+
+        <TextView
+            android:id="@+id/tvAppName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:ellipsize="end"
+            android:maxLines="1"
+            tools:text="Gmail" />
+
+        <TextView
+            android:id="@+id/tvPackageName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="11sp"
+            android:textColor="@color/text_secondary"
+            android:ellipsize="end"
+            android:maxLines="1"
+            tools:text="com.google.android.gm" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/btnOff"
+            android:layout_width="wrap_content"
+            android:layout_height="30dp"
+            android:gravity="center"
+            android:text="Off"
+            android:textSize="11sp"
+            android:paddingHorizontal="10dp"
+            android:background="@drawable/bg_segment_unselected" />
+
+        <TextView
+            android:id="@+id/btnAuto"
+            android:layout_width="wrap_content"
+            android:layout_height="30dp"
+            android:gravity="center"
+            android:text="Auto"
+            android:textSize="11sp"
+            android:paddingHorizontal="10dp"
+            android:layout_marginHorizontal="4dp"
+            android:background="@drawable/bg_segment_unselected" />
+
+        <TextView
+            android:id="@+id/btnMax"
+            android:layout_width="wrap_content"
+            android:layout_height="30dp"
+            android:gravity="center"
+            android:text="Max"
+            android:textSize="11sp"
+            android:paddingHorizontal="10dp"
+            android:background="@drawable/bg_segment_unselected" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,13 @@
     <string name="battery_optimization_title">🔋 Battery Optimization</string>
     <string name="battery_optimization_desc">Efficient background processing - minimal battery usage</string>
     <string name="supported_apps">Supports: SMS, Email, Banking, Social Media &amp; more</string>
+    <string name="app_filter_info_title">Per-App OTP Detection</string>
+    <string name="app_filter_info_desc">Off = ignore this app entirely\nAuto = standard OTP detection (default)\nMax = aggressive detection for apps that use short numeric or letter-only codes</string>
+    <string name="app_filter_loading">Loading installed apps…</string>
+    <string name="app_filter_search_hint">Search apps…</string>
+    <string-array name="app_filter_states">
+        <item>Auto</item>
+        <item>Off</item>
+        <item>Max</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
This PR would solve my issue, #5, adding a new button on the main screen that takes the user to an "App filter", where users can "deactivate" apps they know won't send OTPs (e.g. calculator, camera, etc) to avoid false positives.

It also adds an "aggressive" (Max) mode to filter the selected apps with a more aggressive regex.

The UI buttons were chosen because SegmentedButtonGroup and MaterialButtonToggleGroup was very heavy on redraws when scrolling fast. These buttons are light enough to not cause lag.

I added some "All X" buttons to facilitate setting all apps to a certain state, since upon testing the first thing I wanted to do was set them all to "All off" and then manually select the apps I wanted to have OTP extraction manually.

:)